### PR TITLE
PHP 8.5 compat, test suite, CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,31 @@
+name: Tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.1', '8.2', '8.3', '8.4', '8.5']
+
+    name: PHP ${{ matrix.php }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: xdebug
+
+      - name: Install dependencies
+        uses: ramsey/composer-install@v3
+
+      - name: Run tests
+        run: composer test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,4 +28,4 @@ jobs:
         uses: ramsey/composer-install@v3
 
       - name: Run tests
-        run: composer test
+        run: composer test:coverage

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 /vendor/
 composer.lock
+.idea
+.phpunit.cache/
+.phpunit.result.cache
+phpunit.xml

--- a/composer.json
+++ b/composer.json
@@ -18,20 +18,32 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "psr/http-message": "^1.0",
         "php-http/client-implementation": "^1.0",
         "php-http/client-common": "^2.2.1",
         "php-http/httplug": "^2.0",
         "php-http/discovery": "^1.0",
-        "symfony/http-client": "^8.0",
+        "symfony/http-client": "^6.0|^7.0|^8.0",
         "nyholm/psr7": "^1.8",
         "psr/http-factory": "^1.1"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "psr-4": {
             "RabbitMq\\ManagementApi\\": "src/"
         }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "RabbitMq\\ManagementApi\\Tests\\": "tests/"
+        }
+    },
+    "scripts": {
+        "test": "@php vendor/bin/phpunit",
+        "test:coverage": "@php vendor/bin/phpunit --coverage-text"
     },
     "extra": {
         "branch-alias": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+         colors="true"
+         bootstrap="./vendor/autoload.php">
+    <testsuites>
+        <testsuite name="RabbitMQ Management API Test Suite">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+    <coverage>
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </coverage>
+</phpunit>

--- a/src/Api/AbstractApi.php
+++ b/src/Api/AbstractApi.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace RabbitMq\ManagementApi\Api;
 
 use RabbitMq\ManagementApi\Client;

--- a/src/Api/Binding.php
+++ b/src/Api/Binding.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace RabbitMq\ManagementApi\Api;
 
 /**
@@ -72,7 +74,7 @@ class Binding extends AbstractApi
      * @param array|null $arguments
      * @return array
      */
-    public function create($vhost, $exchange, $queue, $routingKey = null, array $arguments = null)
+    public function create($vhost, $exchange, $queue, $routingKey = null, ?array $arguments = null)
     {
         $parameters = array();
 
@@ -105,7 +107,7 @@ class Binding extends AbstractApi
      * @param array|null $arguments
      * @return array
      */
-    public function createExchange($vhost, $source, $destination, $routingKey = null, array $arguments = null)
+    public function createExchange($vhost, $source, $destination, $routingKey = null, ?array $arguments = null)
     {
         $parameters = array();
 

--- a/src/Api/Channel.php
+++ b/src/Api/Channel.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace RabbitMq\ManagementApi\Api;
 
 /**

--- a/src/Api/Connection.php
+++ b/src/Api/Connection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace RabbitMq\ManagementApi\Api;
 
 /**

--- a/src/Api/Consumer.php
+++ b/src/Api/Consumer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace RabbitMq\ManagementApi\Api;
 
 /**

--- a/src/Api/Exchange.php
+++ b/src/Api/Exchange.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace RabbitMq\ManagementApi\Api;
 
 use RabbitMq\ManagementApi\Exception\InvalidArgumentException;

--- a/src/Api/Node.php
+++ b/src/Api/Node.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace RabbitMq\ManagementApi\Api;
 
 /**

--- a/src/Api/Parameter.php
+++ b/src/Api/Parameter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace RabbitMq\ManagementApi\Api;
 
 /**

--- a/src/Api/Permission.php
+++ b/src/Api/Permission.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace RabbitMq\ManagementApi\Api;
 
 use RabbitMq\ManagementApi\Exception\InvalidArgumentException;

--- a/src/Api/Policy.php
+++ b/src/Api/Policy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace RabbitMq\ManagementApi\Api;
 
 /**

--- a/src/Api/Queue.php
+++ b/src/Api/Queue.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace RabbitMq\ManagementApi\Api;
 
 /**

--- a/src/Api/User.php
+++ b/src/Api/User.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace RabbitMq\ManagementApi\Api;
 
 /**

--- a/src/Api/Vhost.php
+++ b/src/Api/Vhost.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace RabbitMq\ManagementApi\Api;
 
 /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace RabbitMq\ManagementApi;
 
 use Http\Client\Common\Plugin\AuthenticationPlugin;
@@ -23,7 +25,7 @@ class Client
     protected string $baseUrl;
 
     public function __construct(
-        ClientInterface $client = null,
+        ?ClientInterface $client = null,
         string $baseUrl = 'http://localhost:15672',
         string $username = 'guest',
         string $password = 'guest'

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace RabbitMq\ManagementApi\Exception;
 
 /**

--- a/tests/Api/AbstractApiTestCase.php
+++ b/tests/Api/AbstractApiTestCase.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RabbitMq\ManagementApi\Tests\Api;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use RabbitMq\ManagementApi\Client;
+
+abstract class AbstractApiTestCase extends TestCase
+{
+    protected Client|MockObject $client;
+
+    protected function setUp(): void
+    {
+        $this->client = $this->createMock(Client::class);
+    }
+}

--- a/tests/Api/BindingTest.php
+++ b/tests/Api/BindingTest.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RabbitMq\ManagementApi\Tests\Api;
+
+use RabbitMq\ManagementApi\Api\Binding;
+
+class BindingTest extends AbstractApiTestCase
+{
+    private Binding $binding;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->binding = new Binding($this->client);
+    }
+
+    public function testAllWithoutVhost(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/bindings')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->binding->all());
+    }
+
+    public function testAllWithVhost(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/bindings/%2F')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->binding->all('/'));
+    }
+
+    public function testBinding(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/bindings/%2F/e/ex/q/queue')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->binding->binding('/', 'ex', 'queue'));
+    }
+
+    public function testExchangeBinding(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/bindings/%2F/e/src/e/dest')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->binding->exchangeBinding('/', 'src', 'dest'));
+    }
+
+    public function testCreate(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with(
+                '/api/bindings/%2F/e/ex/q/queue',
+                'POST',
+                [],
+                ['routing_key' => 'rk', 'arguments' => ['x-match' => 'all']]
+            )
+            ->willReturn([]);
+
+        $this->assertSame([], $this->binding->create('/', 'ex', 'queue', 'rk', ['x-match' => 'all']));
+    }
+
+    public function testCreateWithDefaults(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with(
+                '/api/bindings/%2F/e/ex/q/queue',
+                'POST',
+                [],
+                ['routing_key' => '']
+            )
+            ->willReturn([]);
+
+        $this->assertSame([], $this->binding->create('/', 'ex', 'queue'));
+    }
+
+    public function testCreateWithNullArguments(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with(
+                '/api/bindings/%2F/e/ex/q/queue',
+                'POST',
+                [],
+                ['routing_key' => 'rk']
+            )
+            ->willReturn([]);
+
+        $this->assertSame([], $this->binding->create('/', 'ex', 'queue', 'rk', null));
+    }
+
+    public function testCreateExchange(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with(
+                '/api/bindings/%2F/e/src/e/dest',
+                'POST',
+                [],
+                ['routing_key' => 'rk', 'arguments' => ['x-match' => 'all']]
+            )
+            ->willReturn([]);
+
+        $this->assertSame([], $this->binding->createExchange('/', 'src', 'dest', 'rk', ['x-match' => 'all']));
+    }
+
+    public function testCreateExchangeWithDefaults(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with(
+                '/api/bindings/%2F/e/src/e/dest',
+                'POST',
+                [],
+                ['routing_key' => '']
+            )
+            ->willReturn([]);
+
+        $this->assertSame([], $this->binding->createExchange('/', 'src', 'dest'));
+    }
+
+    public function testCreateExchangeWithNullArguments(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with(
+                '/api/bindings/%2F/e/src/e/dest',
+                'POST',
+                [],
+                ['routing_key' => 'rk']
+            )
+            ->willReturn([]);
+
+        $this->assertSame([], $this->binding->createExchange('/', 'src', 'dest', 'rk', null));
+    }
+
+    public function testGet(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/bindings/%2F/e/ex/q/queue/props')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->binding->get('/', 'ex', 'queue', 'props'));
+    }
+
+    public function testGetExchange(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/bindings/%2F/e/src/e/dest/props')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->binding->getExchange('/', 'src', 'dest', 'props'));
+    }
+
+    public function testDelete(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/bindings/%2F/e/ex/q/queue/props', 'DELETE')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->binding->delete('/', 'ex', 'queue', 'props'));
+    }
+
+    public function testDeleteExchange(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/bindings/%2F/e/src/e/dest/props', 'DELETE')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->binding->deleteExchange('/', 'src', 'dest', 'props'));
+    }
+}

--- a/tests/Api/ChannelTest.php
+++ b/tests/Api/ChannelTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RabbitMq\ManagementApi\Tests\Api;
+
+use RabbitMq\ManagementApi\Api\Channel;
+
+class ChannelTest extends AbstractApiTestCase
+{
+    private Channel $channel;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->channel = new Channel($this->client);
+    }
+
+    public function testAll(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/channels')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->channel->all());
+    }
+
+    public function testGet(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/channels/ch1')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->channel->get('ch1'));
+    }
+}

--- a/tests/Api/ConnectionTest.php
+++ b/tests/Api/ConnectionTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RabbitMq\ManagementApi\Tests\Api;
+
+use RabbitMq\ManagementApi\Api\Connection;
+
+class ConnectionTest extends AbstractApiTestCase
+{
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->connection = new Connection($this->client);
+    }
+
+    public function testAll(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/connections')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->connection->all());
+    }
+
+    public function testGet(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/connections/conn1')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->connection->get('conn1'));
+    }
+
+    public function testDelete(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/connections/conn1', 'DELETE')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->connection->delete('conn1'));
+    }
+}

--- a/tests/Api/ConsumerTest.php
+++ b/tests/Api/ConsumerTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RabbitMq\ManagementApi\Tests\Api;
+
+use RabbitMq\ManagementApi\Api\Consumer;
+
+class ConsumerTest extends AbstractApiTestCase
+{
+    private Consumer $consumer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->consumer = new Consumer($this->client);
+    }
+
+    public function testAll(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/consumers')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->consumer->all());
+    }
+
+    public function testGet(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/consumers/%2F')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->consumer->get('/'));
+    }
+}

--- a/tests/Api/ExchangeTest.php
+++ b/tests/Api/ExchangeTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RabbitMq\ManagementApi\Tests\Api;
+
+use RabbitMq\ManagementApi\Api\Exchange;
+
+class ExchangeTest extends AbstractApiTestCase
+{
+    private Exchange $exchange;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->exchange = new Exchange($this->client);
+    }
+
+    public function testAllWithoutVhost(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/exchanges')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->exchange->all());
+    }
+
+    public function testAllWithVhost(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/exchanges/%2F')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->exchange->all('/'));
+    }
+
+    public function testGet(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/exchanges/%2F/amq.direct')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->exchange->get('/', 'amq.direct'));
+    }
+
+    public function testCreate(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/exchanges/%2F/test', 'PUT', [], ['type' => 'direct'])
+            ->willReturn([]);
+
+        $this->assertSame([], $this->exchange->create('/', 'test', ['type' => 'direct']));
+    }
+
+    public function testDelete(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/exchanges/%2F/test', 'DELETE')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->exchange->delete('/', 'test'));
+    }
+
+    public function testSourceBindings(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/exchanges/%2F/amq.direct/bindings/source')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->exchange->sourceBindings('/', 'amq.direct'));
+    }
+
+    public function testDestinationBindings(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/exchanges/%2F/amq.direct/bindings/destination')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->exchange->destinationBindings('/', 'amq.direct'));
+    }
+
+    public function testPublish(): void
+    {
+        $message = ['properties' => [], 'routing_key' => 'rk', 'payload' => 'test', 'payload_encoding' => 'string'];
+
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/exchanges/%2F/amq.direct/publish', 'POST', [], $message)
+            ->willReturn(['routed' => true]);
+
+        $this->assertSame(['routed' => true], $this->exchange->publish('/', 'amq.direct', $message));
+    }
+
+    public function testCreateThrowsWithoutType(): void
+    {
+        $this->expectException(\RabbitMq\ManagementApi\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Exchange key 'type' is mandatory");
+
+        $this->exchange->create('/', 'test', ['durable' => true]);
+    }
+
+    public function testPublishThrowsWithoutProperties(): void
+    {
+        $this->expectException(\RabbitMq\ManagementApi\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Message key 'properties' is mandatory");
+
+        $this->exchange->publish('/', 'amq.direct', ['routing_key' => 'rk', 'payload' => 'test', 'payload_encoding' => 'string']);
+    }
+
+    public function testPublishThrowsWithoutRoutingKey(): void
+    {
+        $this->expectException(\RabbitMq\ManagementApi\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Message key 'routing_key' is mandatory");
+
+        $this->exchange->publish('/', 'amq.direct', ['properties' => []]);
+    }
+
+    public function testPublishThrowsWithoutPayload(): void
+    {
+        $this->expectException(\RabbitMq\ManagementApi\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Message key 'payload' is mandatory");
+
+        $this->exchange->publish('/', 'amq.direct', ['properties' => [], 'routing_key' => 'rk']);
+    }
+
+    public function testPublishThrowsWithoutPayloadEncoding(): void
+    {
+        $this->expectException(\RabbitMq\ManagementApi\Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Message key 'payload_encoding' is mandatory");
+
+        $this->exchange->publish('/', 'amq.direct', ['properties' => [], 'routing_key' => 'rk', 'payload' => 'test']);
+    }
+}

--- a/tests/Api/NodeTest.php
+++ b/tests/Api/NodeTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RabbitMq\ManagementApi\Tests\Api;
+
+use RabbitMq\ManagementApi\Api\Node;
+
+class NodeTest extends AbstractApiTestCase
+{
+    private Node $node;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->node = new Node($this->client);
+    }
+
+    public function testAll(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/nodes')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->node->all());
+    }
+
+    public function testGet(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/nodes/rabbit%40localhost')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->node->get('rabbit@localhost'));
+    }
+
+    public function testGetWithMemory(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/nodes/rabbit%40localhost?memory=true')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->node->get('rabbit@localhost', true));
+    }
+}

--- a/tests/Api/ParameterTest.php
+++ b/tests/Api/ParameterTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RabbitMq\ManagementApi\Tests\Api;
+
+use RabbitMq\ManagementApi\Api\Parameter;
+
+class ParameterTest extends AbstractApiTestCase
+{
+    private Parameter $parameter;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->parameter = new Parameter($this->client);
+    }
+
+    public function testAll(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/parameters')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->parameter->all());
+    }
+
+    public function testGetByComponent(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/parameters/federation')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->parameter->get('federation'));
+    }
+
+    public function testGetByComponentAndVhost(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/parameters/federation/%2F')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->parameter->get('federation', '/'));
+    }
+
+    public function testGetByComponentVhostAndName(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/parameters/federation/%2F/my-param')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->parameter->get('federation', '/', 'my-param'));
+    }
+
+    public function testCreate(): void
+    {
+        $params = ['value' => ['uri' => 'amqp://remote']];
+
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/parameters/federation/%2F/my-param', 'PUT', [], $params)
+            ->willReturn([]);
+
+        $this->assertSame([], $this->parameter->create('federation', '/', 'my-param', $params));
+    }
+
+    public function testDelete(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/parameters/federation/%2F/my-param', 'DELETE')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->parameter->delete('federation', '/', 'my-param'));
+    }
+}

--- a/tests/Api/PermissionTest.php
+++ b/tests/Api/PermissionTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RabbitMq\ManagementApi\Tests\Api;
+
+use RabbitMq\ManagementApi\Api\Permission;
+
+class PermissionTest extends AbstractApiTestCase
+{
+    private Permission $permission;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->permission = new Permission($this->client);
+    }
+
+    public function testAll(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/permissions')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->permission->all());
+    }
+
+    public function testGet(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/permissions/%2F/guest')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->permission->get('/', 'guest'));
+    }
+
+    public function testCreate(): void
+    {
+        $perms = ['configure' => '.*', 'write' => '.*', 'read' => '.*'];
+
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/permissions/%2F/guest', 'PUT', [], $perms)
+            ->willReturn([]);
+
+        $this->assertSame([], $this->permission->create('/', 'guest', $perms));
+    }
+
+    public function testCreateThrowsWithMissingKeys(): void
+    {
+        $this->expectException(\RabbitMq\ManagementApi\Exception\InvalidArgumentException::class);
+
+        $this->permission->create('/', 'guest', ['configure' => '.*']);
+    }
+
+    public function testDelete(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/permissions/%2F/guest', 'DELETE')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->permission->delete('/', 'guest'));
+    }
+}

--- a/tests/Api/PolicyTest.php
+++ b/tests/Api/PolicyTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RabbitMq\ManagementApi\Tests\Api;
+
+use RabbitMq\ManagementApi\Api\Policy;
+
+class PolicyTest extends AbstractApiTestCase
+{
+    private Policy $policy;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->policy = new Policy($this->client);
+    }
+
+    public function testAll(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/policies')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->policy->all());
+    }
+
+    public function testGetByVhost(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/policies/%2F')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->policy->get('/'));
+    }
+
+    public function testGetByVhostAndName(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/policies/%2F/ha-all')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->policy->get('/', 'ha-all'));
+    }
+
+    public function testCreate(): void
+    {
+        $policyDef = ['pattern' => '.*', 'definition' => ['ha-mode' => 'all']];
+
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/policies/%2F/ha-all', 'PUT', [], $policyDef)
+            ->willReturn([]);
+
+        $this->assertSame([], $this->policy->create('/', 'ha-all', $policyDef));
+    }
+
+    public function testDelete(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/policies/%2F/ha-all', 'DELETE')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->policy->delete('/', 'ha-all'));
+    }
+}

--- a/tests/Api/QueueTest.php
+++ b/tests/Api/QueueTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RabbitMq\ManagementApi\Tests\Api;
+
+use RabbitMq\ManagementApi\Api\Queue;
+
+class QueueTest extends AbstractApiTestCase
+{
+    private Queue $queue;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->queue = new Queue($this->client);
+    }
+
+    public function testAllWithoutVhost(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/queues')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->queue->all());
+    }
+
+    public function testAllWithVhost(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/queues/%2F')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->queue->all('/'));
+    }
+
+    public function testGet(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/queues/%2F/test')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->queue->get('/', 'test'));
+    }
+
+    public function testCreate(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/queues/%2F/test', 'PUT', [], ['durable' => true])
+            ->willReturn([]);
+
+        $this->assertSame([], $this->queue->create('/', 'test', ['durable' => true]));
+    }
+
+    public function testDelete(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/queues/%2F/test?', 'DELETE')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->queue->delete('/', 'test'));
+    }
+
+    public function testDeleteIfEmpty(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/queues/%2F/test?if-empty=true', 'DELETE')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->queue->delete('/', 'test', true));
+    }
+
+    public function testDeleteIfUnused(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/queues/%2F/test?if-unused=true', 'DELETE')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->queue->delete('/', 'test', false, true));
+    }
+
+    public function testBindings(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/queues/%2F/test/bindings')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->queue->bindings('/', 'test'));
+    }
+
+    public function testPurgeMessages(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/queues/%2F/test/contents', 'DELETE')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->queue->purgeMessages('/', 'test'));
+    }
+
+    public function testRetrieveMessages(): void
+    {
+        $expected = ['count' => 5, 'requeue' => true, 'encoding' => 'auto'];
+
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/queues/%2F/test/get', 'POST', [], $expected)
+            ->willReturn([]);
+
+        $this->assertSame([], $this->queue->retrieveMessages('/', 'test'));
+    }
+
+    public function testRetrieveMessagesWithTruncate(): void
+    {
+        $expected = ['count' => 1, 'requeue' => false, 'encoding' => 'base64', 'truncate' => 100];
+
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/queues/%2F/test/get', 'POST', [], $expected)
+            ->willReturn([]);
+
+        $this->assertSame([], $this->queue->retrieveMessages('/', 'test', 1, false, 'base64', 100));
+    }
+}

--- a/tests/Api/UserTest.php
+++ b/tests/Api/UserTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RabbitMq\ManagementApi\Tests\Api;
+
+use RabbitMq\ManagementApi\Api\User;
+
+class UserTest extends AbstractApiTestCase
+{
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = new User($this->client);
+    }
+
+    public function testAll(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/users')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->user->all());
+    }
+
+    public function testGet(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/users/guest')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->user->get('guest'));
+    }
+
+    public function testCreate(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/users/admin', 'PUT', [], ['password' => 'secret', 'tags' => 'administrator'])
+            ->willReturn([]);
+
+        $this->assertSame([], $this->user->create('admin', ['password' => 'secret', 'tags' => 'administrator']));
+    }
+
+    public function testDelete(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/users/guest', 'DELETE')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->user->delete('guest'));
+    }
+
+    public function testPermissions(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/users/guest/permissions')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->user->permissions('guest'));
+    }
+}

--- a/tests/Api/VhostTest.php
+++ b/tests/Api/VhostTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RabbitMq\ManagementApi\Tests\Api;
+
+use RabbitMq\ManagementApi\Api\Vhost;
+
+class VhostTest extends AbstractApiTestCase
+{
+    private Vhost $vhost;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->vhost = new Vhost($this->client);
+    }
+
+    public function testAll(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/vhosts')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->vhost->all());
+    }
+
+    public function testGet(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/vhosts/%2F')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->vhost->get('/'));
+    }
+
+    public function testCreate(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/vhosts/test', 'PUT')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->vhost->create('test'));
+    }
+
+    public function testDelete(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/vhosts/test', 'DELETE')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->vhost->delete('test'));
+    }
+
+    public function testPermissions(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/vhosts/%2F/permissions')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->vhost->permissions('/'));
+    }
+}

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RabbitMq\ManagementApi\Tests;
+
+use Nyholm\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use RabbitMq\ManagementApi\Api;
+use RabbitMq\ManagementApi\Client;
+
+class ClientTest extends TestCase
+{
+    private Client $client;
+
+    protected function setUp(): void
+    {
+        $this->client = $this->getMockBuilder(Client::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['send'])
+            ->getMock();
+    }
+
+    public function testConnections(): void
+    {
+        $this->assertInstanceOf(Api\Connection::class, $this->client->connections());
+    }
+
+    public function testChannels(): void
+    {
+        $this->assertInstanceOf(Api\Channel::class, $this->client->channels());
+    }
+
+    public function testConsumers(): void
+    {
+        $this->assertInstanceOf(Api\Consumer::class, $this->client->consumers());
+    }
+
+    public function testExchanges(): void
+    {
+        $this->assertInstanceOf(Api\Exchange::class, $this->client->exchanges());
+    }
+
+    public function testQueues(): void
+    {
+        $this->assertInstanceOf(Api\Queue::class, $this->client->queues());
+    }
+
+    public function testVhosts(): void
+    {
+        $this->assertInstanceOf(Api\Vhost::class, $this->client->vhosts());
+    }
+
+    public function testBindings(): void
+    {
+        $this->assertInstanceOf(Api\Binding::class, $this->client->bindings());
+    }
+
+    public function testUsers(): void
+    {
+        $this->assertInstanceOf(Api\User::class, $this->client->users());
+    }
+
+    public function testPermissions(): void
+    {
+        $this->assertInstanceOf(Api\Permission::class, $this->client->permissions());
+    }
+
+    public function testParameters(): void
+    {
+        $this->assertInstanceOf(Api\Parameter::class, $this->client->parameters());
+    }
+
+    public function testPolicies(): void
+    {
+        $this->assertInstanceOf(Api\Policy::class, $this->client->policies());
+    }
+
+    public function testAlivenessTest(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/aliveness-test/%2F')
+            ->willReturn(['status' => 'ok']);
+
+        $this->assertSame(['status' => 'ok'], $this->client->alivenessTest('/'));
+    }
+
+    public function testOverview(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/overview')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->client->overview());
+    }
+
+    public function testExtensions(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/extensions')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->client->extensions());
+    }
+
+    public function testDefinitions(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/definitions')
+            ->willReturn([]);
+
+        $this->assertSame([], $this->client->definitions());
+    }
+
+    public function testWhoami(): void
+    {
+        $this->client->expects($this->once())
+            ->method('send')
+            ->with('/api/whoami')
+            ->willReturn(['name' => 'guest']);
+
+        $this->assertSame(['name' => 'guest'], $this->client->whoami());
+    }
+
+    public function testConstructorWithMockedHttpClient(): void
+    {
+        $httpClient = $this->createMock(ClientInterface::class);
+        $client = new Client($httpClient, 'http://rabbit:15672', 'admin', 'secret');
+
+        $this->assertInstanceOf(Client::class, $client);
+    }
+
+    public function testConstructorWithDefaultClient(): void
+    {
+        $client = new Client(null, 'http://rabbit:15672');
+
+        $this->assertInstanceOf(Client::class, $client);
+    }
+
+    public function testSendGetRequest(): void
+    {
+        $httpClient = $this->createMock(ClientInterface::class);
+        $httpClient->expects($this->once())
+            ->method('sendRequest')
+            ->with($this->callback(function (RequestInterface $request) {
+                return $request->getMethod() === 'GET'
+                    && (string)$request->getUri() === 'http://rabbit:15672/api/overview';
+            }))
+            ->willReturn(new Response(200, [], '{"cluster_name":"rabbit@localhost"}'));
+
+        $client = new Client($httpClient, 'http://rabbit:15672');
+        $result = $client->send('/api/overview');
+
+        $this->assertSame(['cluster_name' => 'rabbit@localhost'], $result);
+    }
+
+    public function testSendPostRequestWithBody(): void
+    {
+        $httpClient = $this->createMock(ClientInterface::class);
+        $httpClient->expects($this->once())
+            ->method('sendRequest')
+            ->with($this->callback(function (RequestInterface $request) {
+                return $request->getMethod() === 'POST'
+                    && (string)$request->getUri() === 'http://rabbit:15672/api/exchanges/%2F/test/publish';
+            }))
+            ->willReturn(new Response(200, [], '{"routed":true}'));
+
+        $client = new Client($httpClient, 'http://rabbit:15672');
+        $result = $client->send('/api/exchanges/%2F/test/publish', 'POST', [], ['payload' => 'test']);
+
+        $this->assertSame(['routed' => true], $result);
+    }
+
+    public function testSendDeleteRequest(): void
+    {
+        $httpClient = $this->createMock(ClientInterface::class);
+        $httpClient->expects($this->once())
+            ->method('sendRequest')
+            ->with($this->callback(function (RequestInterface $request) {
+                return $request->getMethod() === 'DELETE'
+                    && (string)$request->getUri() === 'http://rabbit:15672/api/queues/%2F/test';
+            }))
+            ->willReturn(new Response(204, [], ''));
+
+        $client = new Client($httpClient, 'http://rabbit:15672');
+        $result = $client->send('/api/queues/%2F/test', 'DELETE');
+
+        $this->assertEmpty($result);
+    }
+
+    public function testSendIncludesAuthHeaders(): void
+    {
+        $httpClient = $this->createMock(ClientInterface::class);
+        $httpClient->expects($this->once())
+            ->method('sendRequest')
+            ->with($this->callback(function (RequestInterface $request) {
+                $auth = $request->getHeaderLine('Authorization');
+                return str_starts_with($auth, 'Basic ')
+                    && base64_decode(substr($auth, 6)) === 'admin:secret';
+            }))
+            ->willReturn(new Response(200, [], '{"name":"admin"}'));
+
+        $client = new Client($httpClient, 'http://rabbit:15672', 'admin', 'secret');
+        $result = $client->send('/api/whoami');
+
+        $this->assertSame(['name' => 'admin'], $result);
+    }
+}


### PR DESCRIPTION
Figured out that requiring `symfony/http-client` as `^8.0` actually pushes the requirement for PHP to 8.4 at least, so despite being declared as ^8.0 in composer.json, this package can't really be installed on anything less than 8.4.

Did some housekeeping, too. Full list of changes:

- Fix implicit nullable parameter deprecations for PHP 8.5 (`Client::__construct`, `Binding::create`, `Binding::createExchange`)
- Add `declare(strict_types=1)` to all PHP files
- Add PHPUnit 9.5 test suite with 100% code coverage (96 tests, 178 assertions)
- Add GitHub Actions CI workflow running tests on PHP 8.1 through 8.5
- Widen `symfony/http-client` constraint from `^8.0` to `^6.0|^7.0|^8.0` for PHP 8.1+ support
- Add `composer test` and `composer test:coverage` scripts
- Update `.gitignore` for PHPUnit cache files

You may need to enable actions in order to have tests running against each (push to) PR.